### PR TITLE
Fix sluggish performance

### DIFF
--- a/lovey-stats
+++ b/lovey-stats
@@ -54,7 +54,7 @@ aws s3 cp "s3://$BUCKETNAME/logs/" "$LOGDIR/" \
 } >> "$CMDLOG"
 
 # Aggregate S3 logs into one file, filter out unnecessary entries
-for i in $LOGDIR/*; do cat "$i" >> "$TMPLOG"; done && sync
+for i in "$LOGDIR/$DATE*"; do cat "$i" >> "$TMPLOG"; done && sync
 cat "$TMPLOG" | grep "REST.GET.OBJECT" \
               | grep -v "user/David" \
               | grep -v localhost \


### PR DESCRIPTION
There is a bug in the way lovey-stats concatenates all of the AWS logs together. Instead of joining just the AWS logs, it also grabs all of the temp logs, the command log, and even the access log and throws them in as well. To fix the issue, simply add the date to the for loop condition. This should fix #1.

This was a stupid mistake, as it was done properly when deleting the logs at the end of the script. Whoops!